### PR TITLE
fix: reorder resource destruction in `ui` destructor

### DIFF
--- a/sources/ui.c
+++ b/sources/ui.c
@@ -35,12 +35,12 @@ static void create_resources(UIClass *self)
 static void destructor(void *ptr)
 {
     UIClass *self = (UIClass *) ptr;
-    SDL_DestroyWindow(self->window);
-    SDL_DestroyRenderer(self->renderer);
     SDL_DestroyTexture(self->texture);
     SDL_DestroyTexture(self->debug_texture);
     SDL_FreeSurface(self->debug_screen);
     SDL_FreeSurface(self->screen);
+    SDL_DestroyRenderer(self->renderer);
+    SDL_DestroyWindow(self->window);
     SDL_Quit();
 }
 


### PR DESCRIPTION
The `UIClass` destructor freed `SDL` resources in an incorrect order, causing a use after free error. This PR addresses that issue by using the correct order.

```
=================================================================
==17173==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d00001d920 at pc 0x00010120b2dc bp 0x00016f896aa0 sp 0x00016f896a98
READ of size 8 at 0x60d00001d920 thread T0
    #0 0x10120b2d8 in SDL_DestroyTexture_REAL SDL_render.c:4317
    #1 0x101157870 in SDL_DestroyTexture SDL_dynapi_procs.h:381
    #2 0x1005a4dc0 in destructor ui.c:40
    #3 0x100592434 in destroy_class oop.c:31
    #4 0x10058211c in destructor gameboy.c:38
    #5 0x100592434 in destroy_class oop.c:31
    #6 0x100591f44 in main main.c:7
    #7 0x189e4c270  (<unknown module>)

0x60d00001d920 is located 0 bytes inside of 144-byte region [0x60d00001d920,0x60d00001d9b0)
freed by thread T0 here:
    #0 0x101a28d40 in free+0x98 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54d40)
    #1 0x1013739c0 in real_free SDL_malloc.c:5199
    #2 0x101373f18 in SDL_free_REAL SDL_malloc.c:5339
    #3 0x10120b924 in SDL_DestroyTexture_REAL SDL_render.c:4352
    #4 0x10123a33c in SDL_DestroyRendererWithoutFreeing SDL_render.c:4389
    #5 0x1015c91c4 in SDL_DestroyWindow_REAL SDL_video.c:3321
    #6 0x10115a398 in SDL_DestroyWindow SDL_dynapi_procs.h:580
    #7 0x1005a4d38 in destructor ui.c:38
    #8 0x100592434 in destroy_class oop.c:31
    #9 0x10058211c in destructor gameboy.c:38
    #10 0x100592434 in destroy_class oop.c:31
    #11 0x100591f44 in main main.c:7
    #12 0x189e4c270  (<unknown module>)

previously allocated by thread T0 here:
    #0 0x101a28fd0 in calloc+0x9c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54fd0)
    #1 0x101373970 in real_calloc SDL_malloc.c:5197
    #2 0x101373de4 in SDL_calloc_REAL SDL_malloc.c:5311
    #3 0x101209c94 in SDL_CreateTexture_REAL SDL_render.c:1319
    #4 0x101156e40 in SDL_CreateTexture SDL_dynapi_procs.h:340
    #5 0x1005a5388 in create_resources ui.c:25
    #6 0x1005a4cc4 in constructor ui.c:12
    #7 0x100592334 in allocate_class oop.c:22
    #8 0x100592098 in new_class oop.c:7
    #9 0x1005819dc in constructor gameboy.c:16
    #10 0x100592334 in allocate_class oop.c:22
    #11 0x100592098 in new_class oop.c:7
    #12 0x100591ee4 in main main.c:5
    #13 0x189e4c270  (<unknown module>)

SUMMARY: AddressSanitizer: heap-use-after-free SDL_render.c:4317 in SDL_DestroyTexture_REAL
Shadow bytes around the buggy address:
  0x60d00001d680: fa fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x60d00001d700: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x60d00001d780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x60d00001d800: 00 00 fa fa fa fa fa fa fa fa 00 00 00 00 00 00
  0x60d00001d880: 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa
=>0x60d00001d900: fa fa fa fa[fd]fd fd fd fd fd fd fd fd fd fd fd
  0x60d00001d980: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fd fd
  0x60d00001da00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x60d00001da80: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x60d00001db00: 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa
  0x60d00001db80: fa fa 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==17173==ABORTING
[1]    17173 abort      ./build/gameboy ROMs/tetris.gb
```